### PR TITLE
Auto-detect magit-gerrit-ssh-creds

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Installation
 
 (require 'magit-gerrit)
 
+;; if remote url is not using the default gerrit port and
+;; ssh scheme, need to manually set this variable
 (setq-default magit-gerrit-ssh-creds "myid@gerrithost.org")
 
 ;; if necessary, use an alternative remote instead of 'origin'

--- a/magit-gerrit.el
+++ b/magit-gerrit.el
@@ -437,10 +437,22 @@
   (when (called-interactively-p 'any)
     (magit-refresh)))
 
+(defun magit-gerrit-detect-ssh-creds (remote-url)
+  "Derive magit-gerrit-ssh-creds from remote-url.
+Assumes remote-url is a gerrit repo if scheme is ssh
+and port is the default gerrit ssh port."
+  (let ((url (url-generic-parse-url remote-url)))
+    (when (and (string= "ssh" (url-type url))
+               (eq 29418 (url-port url)))
+      (set (make-local-variable 'magit-gerrit-ssh-creds)
+           (format "%s@%s" (url-user url) (url-host url)))
+      (message "Detected magit-gerrit-ssh-creds=%s" magit-gerrit-ssh-creds))))
+
 (defun magit-gerrit-check-enable ()
   (let ((remote-url (magit-gerrit-get-remote-url)))
     (when (and remote-url
-	       magit-gerrit-ssh-creds
+	       (or magit-gerrit-ssh-creds
+                   (magit-gerrit-detect-ssh-creds remote-url))
 	       (string-match magit-gerrit-ssh-creds remote-url))
      (magit-gerrit-mode t))))
 


### PR DESCRIPTION
If magit-gerrit-ssh-creds is not set, assume gerrit repo
if remote-url scheme is ssh and port is the defalt gerrit
ssh port.
