### PR TITLE
Support remotes using the url.<base>.insteadOf scheme

### DIFF
--- a/magit-gerrit.el
+++ b/magit-gerrit.el
@@ -130,7 +130,7 @@
   (gerrit-ssh-cmd "review" "--project" prj "--verified" score rev))
 
 (defun magit-gerrit-get-remote-url ()
-  (magit-get "remote" magit-gerrit-remote "url"))
+  (magit-git-string "ls-remote" "--get-url" magit-gerrit-remote))
 
 (defun magit-gerrit-get-project ()
  (let* ((regx (rx (zero-or-one ?:) (zero-or-more (any digit)) ?/


### PR DESCRIPTION
When using the url.<base>.insteadOf [1](http://git-scm.com/docs/git-config) scheme `git config --get
remote.<name>.url` will return an alias instead of the actual URL.  By
using `git ls-remote --get-url <name>` the actual URL can be obtained.

Change-Id: I4257c454daafd7bb4e60953ac520ecdab96f5d42
