### PR TITLE
Use correct remote for viewing patchset diff

### DIFF
--- a/magit-gerrit.el
+++ b/magit-gerrit.el
@@ -254,8 +254,9 @@
 	    (dir default-directory)
 	    (buf (get-buffer-create magit-diff-buffer-name)))
 	(let* ((magit-custom-options (list ref))
-	       (magit-proc (magit-fetch-current)))
-	  (message "Waiting for git fetch to complete...")
+           (magit-proc (magit-fetch magit-gerrit-remote)))
+      (message (format "Waiting a git fetch from %s to complete..."
+                       magit-gerrit-remote))
 	  (magit-process-wait))
 	(message (format "Generating Gerrit Patchset for refs %s dir %s" ref dir))
 	(magit-diff "FETCH_HEAD~1..FETCH_HEAD")))))


### PR DESCRIPTION
Fixes failing `magit-gerrit-view-patchset-diff' command when using
non-default remote. Even though`magit-gerrit-remote' was set, the
command didn't use it.
