### PR TITLE
Use patch set number for branch name if no topic

### DIFF
--- a/magit-gerrit.el
+++ b/magit-gerrit.el
@@ -283,7 +283,7 @@ Succeed even if branch already exist
 	    (dir default-directory)
         (branch (format "review/%s/%s"
                         (cdr (assoc 'username (assoc 'owner jobj)))
-                        (cdr (assoc 'topic jobj)))))
+                        (cdr (or (assoc 'topic jobj) (assoc 'number jobj))))))
 	(let* ((magit-custom-options (list ref))
            (magit-proc (magit-fetch magit-gerrit-remote)))
       (message (format "Waiting a git fetch from %s to complete..."


### PR DESCRIPTION
When downloading a Gerrit patch set, the local branch is created with
the naming scheme `review/AUTHOR/TOPIC`. But if no topic was set on the
patch set, this was resulting in a branch name `review/AUTHOR/nil`. To
avoid this, the patch set number is now used instead if no topic is
available, so that the branch will be named `review/AUTHOR/NUMBER` in
such cases. This behavior is also consistent with the one of the
`git-review` tool.
