### PR TITLE
magit-popup: require the library

### DIFF
--- a/magit-gerrit.el
+++ b/magit-gerrit.el
@@ -71,6 +71,8 @@
 ;;; Code:
 
 (require 'magit)
+(if (locate-library "magit-popup")
+    (require 'magit-popup))
 (require 'json)
 
 (eval-when-compile


### PR DESCRIPTION
If magit-popup is not loaded at load time of magit-gerrit, the following
error will occur:

  Symbol's value as variable is void: magit-gerrit-popup

This should fix #25 