### PR TITLE
Don't use obsoleted variable name

### DIFF
--- a/magit-gerrit.el
+++ b/magit-gerrit.el
@@ -253,7 +253,7 @@ Succeed even if branch already exist
 
 (defun magit-gerrit-section (section title washer &rest args)
   (let ((magit-git-executable (executable-find "ssh"))
-	(magit-git-standard-options nil))
+	(magit-git-global-arguments nil))
     (magit-insert-section (section title)
       (magit-insert-heading title)
       (magit-git-wash washer (split-string (car args)))


### PR DESCRIPTION
magit-git-standard-options was obsoleted since magit 2.1.0. You can see this by byte-compiling as below.

```
In magit-gerrit-section:                                                               
magit-gerrit.el:257:10:Warning: `magit-git-standard-options' is an obsolete
    variable (as of 2.1.0); use `magit-git-global-arguments' instead.
```