### PR TITLE
magit-fetch-current has been removed, use magit-fetch-from-upstream

### DIFF
--- a/magit-gerrit.el
+++ b/magit-gerrit.el
@@ -453,10 +453,7 @@ Succeed even if branch already exist
 		  (magit-gerrit-get-project)
 		  "--submit"
 		  args)
-  (let* ((branch (or (magit-get-current-branch)
-		     (error "Don't push a detached head.  That's gross")))
-	 (branch-remote (and branch (magit-get "branch" branch "remote"))))
-    (magit-fetch-current branch-remote)))
+  (magit-fetch-from-upstream ""))
 
 (defun magit-gerrit-push-review (status use-pub-branch topic)
   (let* ((branch (or (magit-get-current-branch)


### PR DESCRIPTION
`magit-fetch-current` has been remove from current magit. Use `magit-fetch-from-upstream` instead.