### PR TITLE
Use receivepack to add default reviewers

### DIFF
--- a/magit-gerrit.el
+++ b/magit-gerrit.el
@@ -92,6 +92,16 @@
 (defvar-local magit-gerrit-use-topics nil
   "Flag that indicates the default option of using a topic when pushing to remote")
 
+(defvar-local magit-gerrit-default-reviewers nil
+  "Default reviewers used to gerrit review")
+
+(defun gerrit-receive-pack-reviewers (reviewers)
+  (if reviewers
+      (format "--receive-pack=git receive-pack %s"
+              (mapconcat #'(lambda (reviewer)
+                             (concat "--reviewer=" reviewer))
+                         magit-gerrit-default-reviewers " "))))
+
 (defcustom magit-gerrit-popup-prefix (kbd "R")
   "Key code to open magit-gerrit popup"
   :group 'magit-gerrit
@@ -484,7 +494,9 @@ Succeed even if branch already exist
 	(setq branch-remote magit-gerrit-remote))
 
       (magit-run-git-async "push" "-v" branch-remote
-			   (concat rev ":" branch-pub)))))
+                           (concat rev ":" branch-pub)
+                           (gerrit-receive-pack-reviewers
+                            magit-gerrit-default-reviewers)))))
 
 (defun magit-gerrit-create-review (&rest args)
   (interactive (magit-gerrit-push-review-arguments))

--- a/magit-gerrit.el
+++ b/magit-gerrit.el
@@ -109,71 +109,71 @@
 
 (defun gerrit-command (cmd &rest args)
   (let ((gcmd (concat
-	       "-x -p 29418 "
-	       (or magit-gerrit-ssh-creds
-		   (error "`magit-gerrit-ssh-creds' must be set!"))
-	       " "
-	       "gerrit "
-	       cmd
-	       " "
-	       (mapconcat 'identity args " "))))
+               "-x -p 29418 "
+               (or magit-gerrit-ssh-creds
+                   (error "`magit-gerrit-ssh-creds' must be set!"))
+               " "
+               "gerrit "
+               cmd
+               " "
+               (mapconcat 'identity args " "))))
     ;; (message (format "Using cmd: %s" gcmd))
     gcmd))
 
 (defun gerrit-query (prj &optional status)
   (gerrit-command "query"
-		  "--format=JSON"
-		  "--all-approvals"
-		  "--comments"
-		  "--current-patch-set"
-		  (concat "project:" prj)
-		  (concat "status:" (or status "open"))))
+                  "--format=JSON"
+                  "--all-approvals"
+                  "--comments"
+                  "--current-patch-set"
+                  (concat "project:" prj)
+                  (concat "status:" (or status "open"))))
 
 (defun gerrit-review ())
 
 (defun gerrit-ssh-cmd (cmd &rest args)
   (apply #'call-process
-	 "ssh" nil nil nil
-	 (split-string (apply #'gerrit-command cmd args))))
+         "ssh" nil nil nil
+         (split-string (apply #'gerrit-command cmd args))))
 
 (defun gerrit-review-abandon (prj rev)
   (gerrit-ssh-cmd "review" "--project" prj "--abandon" rev))
 
 (defun gerrit-review-submit (prj rev &optional msg)
   (gerrit-ssh-cmd "review" "--project" prj "--submit"
-		  (if msg msg "") rev))
+                  (if msg msg "") rev))
 
 (defun gerrit-code-review (prj rev score &optional msg)
   (gerrit-ssh-cmd "review" "--project" prj "--code-review" score
-		  (if msg msg "") rev))
+                  (if msg msg "") rev))
 
 (defun gerrit-review-verify (prj rev score &optional msg)
   (gerrit-ssh-cmd "review" "--project" prj "--verified" score
-		  (if msg msg "") rev))
+                  (if msg msg "") rev))
 
 (defun magit-gerrit-get-remote-url ()
   (magit-git-string "ls-remote" "--get-url" magit-gerrit-remote))
 
 (defun magit-gerrit-get-project ()
- (let* ((regx (rx (zero-or-one ?:) (zero-or-more (any digit)) ?/
-		  (group (not (any "/")))
-		  (group (one-or-more (not (any "."))))))
-	(str (or (magit-gerrit-get-remote-url) ""))
-	(sstr (car (last (split-string str "//")))))
-   (when (string-match regx sstr)
-     (concat (match-string 1 sstr)
-	     (match-string 2 sstr)))))
+  (let* ((regx (rx (zero-or-one ?:) (zero-or-more (any digit)) ?/
+                   (group (not (any "/")))
+                   (group (one-or-more (not (any "."))))))
+         (str (or (magit-gerrit-get-remote-url) ""))
+         (sstr (car (last (split-string str "//")))))
+    (when (string-match regx sstr)
+      (concat (match-string 1 sstr)
+              (match-string 2 sstr)))))
 
 (defun magit-gerrit-query (prompt cands)
   (let ((cmp-read (if (functionp 'ido-completing-read-haha)
-		      #'ido-completing-read
-		    #'completing-read)))
+                      #'ido-completing-read
+                    #'completing-read)))
 
-   (funcall cmp-read
-    prompt
-    cands
-    nil
-    t)))
+    (funcall cmp-read
+             prompt
+             cands
+             nil
+             t)))
 
 (defun magit-gerrit-query-remote-branch-merge ()
   (interactive)
@@ -183,31 +183,31 @@
    (let ((rbs (magit-list-remote-branch-names)))
      (mapcar
       #'(lambda (rb)
-	  (and (string-match (rx bos
-				 (one-or-more (not (any "/")))
-				 "/"
-				 (group (one-or-more any))
-				 eos)
-			     rb)
-	       (concat ;;"refs/publish/"
-		(match-string 1 rb)
-		)))
+          (and (string-match (rx bos
+                                 (one-or-more (not (any "/")))
+                                 "/"
+                                 (group (one-or-more any))
+                                 eos)
+                             rb)
+               (concat ;;"refs/publish/"
+                (match-string 1 rb)
+                )))
       rbs))))
 
 (defun magit-gerrit-convert-ref (ref-str from &optional to)
   "Cuts or converts a ref string prefix, e.g.  refs/heads/branch -> refs/publish/branch"
   (or (when (string-match (concat from
-			     (rx (group (one-or-more any))))
-			  ref-str)
-	(format "%s%s"
-		(or (and to (format "refs/%s/" to)) "")
-		(match-string 1 ref-str)))
+                                  (rx (group (one-or-more any))))
+                          ref-str)
+        (format "%s%s"
+                (or (and to (format "refs/%s/" to)) "")
+                (match-string 1 ref-str)))
       ref-str))
 
 (defun magit-gerrit-string-trunc (str maxlen)
   (if (> (length str) maxlen)
       (concat (substring str 0 maxlen)
-	      "...")
+              "...")
     str))
 
 (defun magit-gerrit-create-branch-force (branch parent)
@@ -216,93 +216,93 @@ Fails if working tree or staging area contain uncommitted changes.
 Succeed even if branch already exist
 \('git checkout -B BRANCH REVISION')."
   (cond ((run-hook-with-args-until-success
-	  'magit-create-branch-hook branch parent))
-	((and branch (not (string= branch "")))
-	 (magit-save-repository-buffers)
-	 (magit-run-git "checkout" "-B" branch parent))))
+          'magit-create-branch-hook branch parent))
+        ((and branch (not (string= branch "")))
+         (magit-save-repository-buffers)
+         (magit-run-git "checkout" "-B" branch parent))))
 
 
 (defun magit-gerrit-pretty-print-reviewer (name email crdone vrdone)
   (let* ((wid (1- (window-width)))
-	 (crstr (propertize (if crdone (format "%+2d" (string-to-number crdone)) "  ")
-			    'face '(magit-diff-lines-heading
-				    bold)))
-	 (vrstr (propertize (if vrdone (format "%+2d" (string-to-number vrdone)) "  ")
-			    'face '(magit-diff-added-highlight
-				    bold)))
-	 (namestr (propertize (or name "") 'face 'magit-refname))
-	 (emailstr (propertize (if email (concat "(" email ")") "")
-			       'face 'change-log-name)))
+         (crstr (propertize (if crdone (format "%+2d" (string-to-number crdone)) "  ")
+                            'face '(magit-diff-lines-heading
+                                    bold)))
+         (vrstr (propertize (if vrdone (format "%+2d" (string-to-number vrdone)) "  ")
+                            'face '(magit-diff-added-highlight
+                                    bold)))
+         (namestr (propertize (or name "") 'face 'magit-refname))
+         (emailstr (propertize (if email (concat "(" email ")") "")
+                               'face 'change-log-name)))
     (format "%-12s%s %s" (concat crstr " " vrstr) namestr emailstr)))
 
 (defun magit-gerrit-pretty-print-review (num subj owner-name &optional draft)
   ;; window-width - two prevents long line arrow from being shown
   (let* ((wid (- (window-width) 2))
-	 (numstr (propertize (format "%-10s" num) 'face 'magit-hash))
-	 (nlen (length numstr))
-	 (authmaxlen (/ wid 4))
+         (numstr (propertize (format "%-10s" num) 'face 'magit-hash))
+         (nlen (length numstr))
+         (authmaxlen (/ wid 4))
 
-	 (author (propertize (magit-gerrit-string-trunc owner-name authmaxlen)
-			     'face 'magit-log-author))
+         (author (propertize (magit-gerrit-string-trunc owner-name authmaxlen)
+                             'face 'magit-log-author))
 
-	 (subjmaxlen (- wid (length author) nlen 6))
+         (subjmaxlen (- wid (length author) nlen 6))
 
-	 (subjstr (propertize (magit-gerrit-string-trunc subj subjmaxlen)
-			      'face
-			      (if draft
-				  'magit-signature-bad
-				'magit-signature-good)))
-	 (authsubjpadding (make-string
-			   (max 0 (- wid (+ nlen 1 (length author) (length subjstr))))
-			   ? )))
+         (subjstr (propertize (magit-gerrit-string-trunc subj subjmaxlen)
+                              'face
+                              (if draft
+                                  'magit-signature-bad
+                                'magit-signature-good)))
+         (authsubjpadding (make-string
+                           (max 0 (- wid (+ nlen 1 (length author) (length subjstr))))
+                           ? )))
     (format "%s%s%s%s\n"
-	    numstr subjstr authsubjpadding author)))
+            numstr subjstr authsubjpadding author)))
 
 (defun magit-gerrit-wash-approval (approval)
   (let* ((approver (cdr-safe (assoc 'by approval)))
-	 (approvname (cdr-safe (assoc 'name approver)))
-	 (approvemail (cdr-safe (assoc 'email approver)))
-	 (type (cdr-safe (assoc 'type approval)))
-	 (verified (string= type "Verified"))
-	 (codereview (string= type "Code-Review"))
-	 (score (cdr-safe (assoc 'value approval))))
+         (approvname (cdr-safe (assoc 'name approver)))
+         (approvemail (cdr-safe (assoc 'email approver)))
+         (type (cdr-safe (assoc 'type approval)))
+         (verified (string= type "Verified"))
+         (codereview (string= type "Code-Review"))
+         (score (cdr-safe (assoc 'value approval))))
 
     (magit-insert-section (review approval)
       (insert (magit-gerrit-pretty-print-reviewer approvname approvemail
-						  (and codereview score)
-						  (and verified score))
-	      "\n"))))
+                                                  (and codereview score)
+                                                  (and verified score))
+              "\n"))))
 
 (defun magit-gerrit-wash-approvals (approvals)
   (mapc #'magit-gerrit-wash-approval approvals))
 
 (defun magit-gerrit-wash-review ()
   (let* ((beg (point))
-	 (jobj (json-read))
-	 (end (point))
-	 (num (cdr-safe (assoc 'number jobj)))
-	 (subj (cdr-safe (assoc 'subject jobj)))
-	 (owner (cdr-safe (assoc 'owner jobj)))
-	 (owner-name (or (cdr-safe (assoc 'name owner))
-			 (cdr-safe (assoc 'username owner))))
-	 (owner-email (cdr-safe (assoc 'email owner)))
-	 (patchsets (cdr-safe (assoc 'currentPatchSet jobj)))
-	 ;; compare w/t since when false the value is => :json-false
-	 (isdraft (eq (cdr-safe (assoc 'isDraft patchsets)) t))
-	 (approvs (cdr-safe (if (listp patchsets)
-				(assoc 'approvals patchsets)
-			      (assoc 'approvals (aref patchsets 0))))))
+         (jobj (json-read))
+         (end (point))
+         (num (cdr-safe (assoc 'number jobj)))
+         (subj (cdr-safe (assoc 'subject jobj)))
+         (owner (cdr-safe (assoc 'owner jobj)))
+         (owner-name (or (cdr-safe (assoc 'name owner))
+                         (cdr-safe (assoc 'username owner))))
+         (owner-email (cdr-safe (assoc 'email owner)))
+         (patchsets (cdr-safe (assoc 'currentPatchSet jobj)))
+         ;; compare w/t since when false the value is => :json-false
+         (isdraft (eq (cdr-safe (assoc 'isDraft patchsets)) t))
+         (approvs (cdr-safe (if (listp patchsets)
+                                (assoc 'approvals patchsets)
+                              (assoc 'approvals (aref patchsets 0))))))
     (if (and beg end)
-	(delete-region beg end))
+        (delete-region beg end))
     (when (and num subj owner-name)
       (magit-insert-section (review subj)
-	(insert (propertize
-		 (magit-gerrit-pretty-print-review num subj owner-name isdraft)
-		 'magit-gerrit-jobj
-		 jobj))
-	(unless (magit-section-hidden (magit-current-section))
-	  (magit-gerrit-wash-approvals approvs))
-	(add-text-properties beg (point) (list 'magit-gerrit-jobj jobj)))
+        (insert (propertize
+                 (magit-gerrit-pretty-print-review num subj owner-name isdraft)
+                 'magit-gerrit-jobj
+                 jobj))
+        (unless (magit-section-hidden (magit-current-section))
+          (magit-gerrit-wash-approvals approvs))
+        (add-text-properties beg (point) (list 'magit-gerrit-jobj jobj)))
       t)))
 
 (defun magit-gerrit-wash-reviews (&rest args)
@@ -310,7 +310,7 @@ Succeed even if branch already exist
 
 (defun magit-gerrit-section (section title washer &rest args)
   (let ((magit-git-executable "ssh")
-	(magit-git-standard-options nil))
+        (magit-git-standard-options nil))
     (magit-insert-section (section title)
       (magit-insert-heading title)
       (magit-git-wash washer (split-string (car args)))
@@ -328,13 +328,13 @@ Succeed even if branch already exist
   (let ((jobj (magit-gerrit-review-at-point)))
     (when jobj
       (let ((ref (cdr (assoc 'ref (assoc 'currentPatchSet jobj))))
-	    (dir default-directory))
-	(let* ((magit-this-process (magit-fetch magit-gerrit-remote ref))))
-	  (message (format "Waiting a git fetch from %s to complete..."
-			   magit-gerrit-remote))
-	  (magit-process-wait)
-	  (message (format "Generating Gerrit Patchset for refs %s dir %s" ref dir)))
-	(magit-diff "FETCH_HEAD~1..FETCH_HEAD"))))
+            (dir default-directory))
+        (let* ((magit-this-process (magit-fetch magit-gerrit-remote ref))))
+        (message (format "Waiting a git fetch from %s to complete..."
+                         magit-gerrit-remote))
+        (magit-process-wait)
+        (message (format "Generating Gerrit Patchset for refs %s dir %s" ref dir)))
+      (magit-diff "FETCH_HEAD~1..FETCH_HEAD"))))
 
 (defun magit-gerrit-download-current-patchset ()
   "Download Current Gerrit Review Patchset"
@@ -342,16 +342,16 @@ Succeed even if branch already exist
   (let ((jobj (magit-gerrit-review-at-point)))
     (when jobj
       (let ((ref (cdr (assoc 'ref (assoc 'currentPatchSet jobj))))
-	    (dir default-directory)
-	    (branch (format "review/%s/%s"
-			    (cdr (assoc 'username (assoc 'owner jobj)))
-			    (cdr (or (assoc 'number jobj))))))
-	(let* ((magit-this-process (magit-fetch magit-gerrit-remote ref))))
-	  (message (format "Waiting a git fetch from %s to complete..."
-			   magit-gerrit-remote))
-	  (magit-process-wait)
-	  (message (format "Checking out refs %s to %s in %s" ref branch dir))
-	  (magit-gerrit-create-branch-force branch "FETCH_HEAD")))))
+            (dir default-directory)
+            (branch (format "review/%s/%s"
+                            (cdr (assoc 'username (assoc 'owner jobj)))
+                            (cdr (or (assoc 'number jobj))))))
+        (let* ((magit-this-process (magit-fetch magit-gerrit-remote ref))))
+        (message (format "Waiting a git fetch from %s to complete..."
+                         magit-gerrit-remote))
+        (magit-process-wait)
+        (message (format "Checking out refs %s to %s in %s" ref branch dir))
+        (magit-gerrit-create-branch-force branch "FETCH_HEAD")))))
 
 (defun magit-gerrit-download-patchsets ()
   "Download All Gerrit Review Patchset"
@@ -380,7 +380,7 @@ Succeed even if branch already exist
   (interactive)
   (let ((jobj (magit-gerrit-review-at-point)))
     (if jobj
-	(browse-url (cdr (assoc 'url jobj))))))
+        (browse-url (cdr (assoc 'url jobj))))))
 
 (defun magit-gerrit-copy-review (with-commit-message)
   "Copy review url and commit message."
@@ -404,17 +404,17 @@ Succeed even if branch already exist
 
 (defun magit-insert-gerrit-reviews ()
   (magit-gerrit-section 'gerrit-reviews
-			"Reviews:" 'magit-gerrit-wash-reviews
-			(gerrit-query (magit-gerrit-get-project))))
+                        "Reviews:" 'magit-gerrit-wash-reviews
+                        (gerrit-query (magit-gerrit-get-project))))
 
 (defun magit-gerrit-add-reviewer ()
   (interactive)
   "ssh -x -p 29418 user@gerrit gerrit set-reviewers --project toplvlroot/prjname --add email@addr"
 
   (gerrit-ssh-cmd "set-reviewers"
-		  "--project" (magit-gerrit-get-project)
-		  "--add" (read-string "Reviewer Name/Email: ")
-		  (cdr-safe (assoc 'id (magit-gerrit-review-at-point)))))
+                  "--project" (magit-gerrit-get-project)
+                  "--add" (read-string "Reviewer Name/Email: ")
+                  (cdr-safe (assoc 'id (magit-gerrit-review-at-point)))))
 
 (defun magit-gerrit-popup-args (&optional something)
   (or (magit-gerrit-arguments) (list "")))
@@ -424,14 +424,14 @@ Succeed even if branch already exist
   (interactive (magit-gerrit-popup-args))
 
   (let ((score (completing-read "Score: "
-				    '("-2" "-1" "0" "+1" "+2")
-				    nil t
-				    "+1"))
-	(rev (cdr-safe (assoc
-		      'revision
-		      (cdr-safe (assoc 'currentPatchSet
-				       (magit-gerrit-review-at-point))))))
-	(prj (magit-gerrit-get-project)))
+                                '("-2" "-1" "0" "+1" "+2")
+                                nil t
+                                "+1"))
+        (rev (cdr-safe (assoc
+                        'revision
+                        (cdr-safe (assoc 'currentPatchSet
+                                         (magit-gerrit-review-at-point))))))
+        (prj (magit-gerrit-get-project)))
     (gerrit-review-verify prj rev score args)
     (magit-refresh)))
 
@@ -439,14 +439,14 @@ Succeed even if branch already exist
   "Perform a Gerrit Code Review"
   (interactive (magit-gerrit-popup-args))
   (let ((score (completing-read "Score: "
-				    '("-2" "-1" "0" "+1" "+2")
-				    nil t
-				    "+1"))
-	(rev (cdr-safe (assoc
-		      'revision
-		      (cdr-safe (assoc 'currentPatchSet
-				       (magit-gerrit-review-at-point))))))
-	(prj (magit-gerrit-get-project)))
+                                '("-2" "-1" "0" "+1" "+2")
+                                nil t
+                                "+1"))
+        (rev (cdr-safe (assoc
+                        'revision
+                        (cdr-safe (assoc 'currentPatchSet
+                                         (magit-gerrit-review-at-point))))))
+        (prj (magit-gerrit-get-project)))
     (gerrit-code-review prj rev score args)
     (magit-refresh)))
 
@@ -455,14 +455,14 @@ Succeed even if branch already exist
   ;; "ssh -x -p 29418 user@gerrit gerrit review REVISION  -- --project PRJ --submit "
   (interactive (magit-gerrit-popup-args))
   (gerrit-ssh-cmd "review"
-		  (cdr-safe (assoc
-			     'revision
-			     (cdr-safe (assoc 'currentPatchSet
-					      (magit-gerrit-review-at-point)))))
-		  "--project"
-		  (magit-gerrit-get-project)
-		  "--submit"
-		  args)
+                  (cdr-safe (assoc
+                             'revision
+                             (cdr-safe (assoc 'currentPatchSet
+                                              (magit-gerrit-review-at-point)))))
+                  "--project"
+                  (magit-gerrit-get-project)
+                  "--submit"
+                  args)
   (magit-fetch-from-upstream ""))
 
 (defun magit-gerrit-push-review (status remote-branch topic)
@@ -492,17 +492,17 @@ Succeed even if branch already exist
   (interactive (magit-gerrit-push-review-arguments))
 
   (let ((rb (car-safe
-	     (delete-if 'null
-			(mapcar (lambda (k) (and
-					     (string-match (rx "rb:" (group (zero-or-more any))) k)
-					     (match-string 1 k)))
-				args))))
-	(tp (car-safe
-	     (delete-if 'null
-			(mapcar (lambda (k) (and
-					     (string-match (rx "tp:" (group (zero-or-more any))) k)
-					     (match-string 1 k)))
-				args)))))
+             (delete-if 'null
+                        (mapcar (lambda (k) (and
+                                             (string-match (rx "rb:" (group (zero-or-more any))) k)
+                                             (match-string 1 k)))
+                                args))))
+        (tp (car-safe
+             (delete-if 'null
+                        (mapcar (lambda (k) (and
+                                             (string-match (rx "tp:" (group (zero-or-more any))) k)
+                                             (match-string 1 k)))
+                                args)))))
 
     (magit-gerrit-push-review 'publish rb tp)))
 
@@ -513,59 +513,59 @@ Succeed even if branch already exist
   (interactive (magit-gerrit-push-review-arguments))
 
   (let ((rb (car-safe
-	     (delete-if 'null
-			(mapcar (lambda (k) (and
-					     (string-match (rx "rb:" (group (zero-or-more any))) k)
-					     (match-string 1 k)))
-				args))))
-	(tp (car-safe
-	     (delete-if 'null
-			(mapcar (lambda (k) (and
-					     (string-match (rx "tp:" (group (zero-or-more any))) k)
-					     (match-string 1 k)))
-				args)))))
+             (delete-if 'null
+                        (mapcar (lambda (k) (and
+                                             (string-match (rx "rb:" (group (zero-or-more any))) k)
+                                             (match-string 1 k)))
+                                args))))
+        (tp (car-safe
+             (delete-if 'null
+                        (mapcar (lambda (k) (and
+                                             (string-match (rx "tp:" (group (zero-or-more any))) k)
+                                             (match-string 1 k)))
+                                args)))))
     (magit-gerrit-push-review 'drafts rb tp)))
 
 (defun magit-gerrit-publish-draft ()
   (interactive)
   (let ((prj (magit-gerrit-get-project))
-	(id (cdr-safe (assoc 'id
-			     (magit-gerrit-review-at-point))))
-	(rev (cdr-safe (assoc
-			'revision
-			(cdr-safe (assoc 'currentPatchSet
-					 (magit-gerrit-review-at-point)))))))
+        (id (cdr-safe (assoc 'id
+                             (magit-gerrit-review-at-point))))
+        (rev (cdr-safe (assoc
+                        'revision
+                        (cdr-safe (assoc 'currentPatchSet
+                                         (magit-gerrit-review-at-point)))))))
     (gerrit-ssh-cmd "review" "--project" prj "--publish" rev))
   (magit-refresh))
 
 (defun magit-gerrit-delete-draft ()
   (interactive)
   (let ((prj (magit-gerrit-get-project))
-	(id (cdr-safe (assoc 'id
-		     (magit-gerrit-review-at-point))))
-	(rev (cdr-safe (assoc
-			'revision
-			(cdr-safe (assoc 'currentPatchSet
-					 (magit-gerrit-review-at-point)))))))
+        (id (cdr-safe (assoc 'id
+                             (magit-gerrit-review-at-point))))
+        (rev (cdr-safe (assoc
+                        'revision
+                        (cdr-safe (assoc 'currentPatchSet
+                                         (magit-gerrit-review-at-point)))))))
     (gerrit-ssh-cmd "review" "--project" prj "--delete" rev))
   (magit-refresh))
 
 (defun magit-gerrit-abandon-review ()
   (interactive)
   (let ((prj (magit-gerrit-get-project))
-	(id (cdr-safe (assoc 'id
-		     (magit-gerrit-review-at-point))))
-	(rev (cdr-safe (assoc
-			'revision
-			(cdr-safe (assoc 'currentPatchSet
-					 (magit-gerrit-review-at-point)))))))
+        (id (cdr-safe (assoc 'id
+                             (magit-gerrit-review-at-point))))
+        (rev (cdr-safe (assoc
+                        'revision
+                        (cdr-safe (assoc 'currentPatchSet
+                                         (magit-gerrit-review-at-point)))))))
     ;; (message "Prj: %s Rev: %s Id: %s" prj rev id)
     (gerrit-review-abandon prj rev)
     (magit-refresh)))
 
 (defun magit-gerrit-read-comment (&rest args)
   (format "\'\"%s\"\'"
-	  (read-from-minibuffer "Message: ")))
+          (read-from-minibuffer "Message: ")))
 
 (defun magit-gerrit-create-branch (branch parent))
 
@@ -573,7 +573,7 @@ Succeed even if branch already exist
   "Popup console for copy review to clipboard."
   'magit-gerrit
   :actions '((?C "url and commit message" magit-gerrit-copy-review-url-commit-message)
-	     (?c "url only" magit-gerrit-copy-review-url)))
+             (?c "url only" magit-gerrit-copy-review-url)))
 
 (magit-define-popup magit-gerrit-patchset-popup
   "Popup console for download and view patchset."
@@ -586,15 +586,15 @@ Succeed even if branch already exist
   "Popup console for pushing reviews to Gerrit"
   'magit-gerrit
   :actions '((?P "Push"                              magit-gerrit-create-review)
-	     (?D "Push Commit For Draft Review"      magit-gerrit-create-draft))
+             (?D "Push Commit For Draft Review"      magit-gerrit-create-draft))
   :options '((?t "Topic"           ""       read-from-minibuffer)
-	     (?b "Remote Branch"   ""       read-from-minibuffer)))
+             (?b "Remote Branch"   ""       read-from-minibuffer)))
 
 (defun magit-gerrit-build-push-popup ()
   "Fill in appropriate values for remote branch and topic and then show the push review popup"
   (interactive)
   (let* ((branch (magit-get-current-branch))
-	 (branch-merge (or (magit-get "branch" branch "merge") "")))
+         (branch-merge (or (magit-get "branch" branch "merge") "")))
 
     (magit-define-popup-action 'magit-gerrit-push-review-popup ?P "Push" 'magit-gerrit-create-review)
     (magit-define-popup-action 'magit-gerrit-push-review-popup ?D "Push Draft Review" 'magit-gerrit-create-draft)
@@ -602,15 +602,15 @@ Succeed even if branch already exist
     (magit-define-popup-option 'magit-gerrit-push-review-popup ?b "Remote Branch"
       "rb:"
       #'(lambda (&rest args)
-	  (interactive)
-	  (magit-gerrit-query-remote-branch-merge))
+          (interactive)
+          (magit-gerrit-query-remote-branch-merge))
       branch-merge)
 
     (magit-define-popup-option 'magit-gerrit-push-review-popup ?t "Topic"
       "tp:"
       #'(lambda (&rest args)
-	  (interactive)
-	  (read-from-minibuffer "Topic: "))
+          (interactive)
+          (read-from-minibuffer "Topic: "))
       branch)
 
     (setq magit-gerrit-push-review-arguments nil)
@@ -619,8 +619,8 @@ Succeed even if branch already exist
       (setq magit-gerrit-push-review-arguments (list (concat "tp:" branch))))
 
     (setq magit-gerrit-push-review-arguments
-	  (append magit-gerrit-push-review-arguments
-		  (list (concat "rb:" (magit-gerrit-convert-ref branch-merge "refs/heads/"))))))
+          (append magit-gerrit-push-review-arguments
+                  (list (concat "rb:" (magit-gerrit-convert-ref branch-merge "refs/heads/"))))))
 
   (magit-gerrit-push-review-popup))
 
@@ -644,25 +644,25 @@ Succeed even if branch already exist
 
   (let ((sectype (magit-section-type (magit-current-section))))
     (cond ((eq sectype 'commit)
-	   (magit-gerrit-build-push-popup))
+           (magit-gerrit-build-push-popup))
 
-	  ((eq sectype 'review)
-	   (magit-gerrit-build-review-popup))
+          ((eq sectype 'review)
+           (magit-gerrit-build-review-popup))
 
-	  (t
-	   (magit-gerrit-popup)))))
+          (t
+           (magit-gerrit-popup)))))
 
 (magit-define-popup magit-gerrit-review-popup
   "Popup console for manipulating gerrit reviews"
   'magit-gerrit
   :actions '((?A "Add Reviewer"                                    magit-gerrit-add-reviewer)
-	     (?V "Verify"                                          magit-gerrit-verify-review)
-	     (?C "Code Review"                                     magit-gerrit-code-review)
-	     (?c "Copy Review"                                     magit-gerrit-copy-review-popup)
-	     (?p "Patchset"                                        magit-gerrit-patchset-popup)
-	     (?S "Submit Review"                                   magit-gerrit-submit-review)
-	     (?B "Abandon Review"                                  magit-gerrit-abandon-review)
-	     (?b "Browse Review"                                   magit-gerrit-browse-review))
+             (?V "Verify"                                          magit-gerrit-verify-review)
+             (?C "Code Review"                                     magit-gerrit-code-review)
+             (?c "Copy Review"                                     magit-gerrit-copy-review-popup)
+             (?p "Patchset"                                        magit-gerrit-patchset-popup)
+             (?S "Submit Review"                                   magit-gerrit-submit-review)
+             (?B "Abandon Review"                                  magit-gerrit-abandon-review)
+             (?b "Browse Review"                                   magit-gerrit-browse-review))
   :options '((?m "Comment"                      "--message "       magit-gerrit-read-comment)))
 
 (magit-define-popup magit-gerrit-popup
@@ -670,16 +670,16 @@ Succeed even if branch already exist
   'magit-gerrit
   :actions '((?P "Push Commit For Review"                          magit-gerrit-build-push-popup)
 
-	     (?p "Publish Draft Patchset"                          magit-gerrit-publish-draft)
-	     (?k "Delete Draft"                                    magit-gerrit-delete-draft)
-	     (?A "Add Reviewer"                                    magit-gerrit-add-reviewer)
-	     (?V "Verify"                                          magit-gerrit-verify-review)
-	     (?C "Code Review"                                     magit-gerrit-code-review)
-	     (?c "Copy Review"                                     magit-gerrit-copy-review-popup)
-	     (?p "Patchset"                                        magit-gerrit-patchset-popup)
-	     (?S "Submit Review"                                   magit-gerrit-submit-review)
-	     (?B "Abandon Review"                                  magit-gerrit-abandon-review)
-	     (?b "Browse Review"                                   magit-gerrit-browse-review))
+             (?p "Publish Draft Patchset"                          magit-gerrit-publish-draft)
+             (?k "Delete Draft"                                    magit-gerrit-delete-draft)
+             (?A "Add Reviewer"                                    magit-gerrit-add-reviewer)
+             (?V "Verify"                                          magit-gerrit-verify-review)
+             (?C "Code Review"                                     magit-gerrit-code-review)
+             (?c "Copy Review"                                     magit-gerrit-copy-review-popup)
+             (?p "Patchset"                                        magit-gerrit-patchset-popup)
+             (?S "Submit Review"                                   magit-gerrit-submit-review)
+             (?B "Abandon Review"                                  magit-gerrit-abandon-review)
+             (?b "Browse Review"                                   magit-gerrit-browse-review))
   :options '((?m "Comment"                      "--message "       magit-gerrit-read-comment)))
 
 ;; Attach Magit Gerrit to Magit's default help popup
@@ -705,26 +705,26 @@ Succeed even if branch already exist
   (cond
    (magit-gerrit-mode
     (magit-add-section-hook 'magit-status-sections-hook
-			    'magit-insert-gerrit-reviews
-			    'magit-insert-stashes t t)
+                            'magit-insert-gerrit-reviews
+                            'magit-insert-stashes t t)
     (add-hook 'magit-create-branch-command-hook
-	      'magit-gerrit-create-branch nil t)
-    ;(add-hook 'magit-pull-command-hook 'magit-gerrit-pull nil t)
+              'magit-gerrit-create-branch nil t)
+                                        ;(add-hook 'magit-pull-command-hook 'magit-gerrit-pull nil t)
     (add-hook 'magit-remote-update-command-hook
-	      'magit-gerrit-remote-update nil t)
+              'magit-gerrit-remote-update nil t)
     (add-hook 'magit-push-command-hook
-	      'magit-gerrit-push nil t))
+              'magit-gerrit-push nil t))
 
    (t
     (remove-hook 'magit-after-insert-stashes-hook
-		 'magit-insert-gerrit-reviews t)
+                 'magit-insert-gerrit-reviews t)
     (remove-hook 'magit-create-branch-command-hook
-		 'magit-gerrit-create-branch t)
-    ;(remove-hook 'magit-pull-command-hook 'magit-gerrit-pull t)
+                 'magit-gerrit-create-branch t)
+                                        ;(remove-hook 'magit-pull-command-hook 'magit-gerrit-pull t)
     (remove-hook 'magit-remote-update-command-hook
-		 'magit-gerrit-remote-update t)
+                 'magit-gerrit-remote-update t)
     (remove-hook 'magit-push-command-hook
-		 'magit-gerrit-push t)))
+                 'magit-gerrit-push t)))
   (when (called-interactively-p 'any)
     (magit-refresh)))
 
@@ -734,17 +734,17 @@ Assumes remote-url is a gerrit repo if scheme is ssh
 and port is the default gerrit ssh port."
   (let ((url (url-generic-parse-url remote-url)))
     (when (and (string= "ssh" (url-type url))
-	       (eq 29418 (url-port url)))
+               (eq 29418 (url-port url)))
       (set (make-local-variable 'magit-gerrit-ssh-creds)
-	   (format "%s@%s" (url-user url) (url-host url)))
+           (format "%s@%s" (url-user url) (url-host url)))
       (message "Detected magit-gerrit-ssh-creds=%s" magit-gerrit-ssh-creds))))
 
 (defun magit-gerrit-check-enable ()
   (let ((remote-url (magit-gerrit-get-remote-url)))
     (when (and remote-url
-	       (or magit-gerrit-ssh-creds
-		   (magit-gerrit-detect-ssh-creds remote-url))
-	       (string-match magit-gerrit-ssh-creds remote-url))
+               (or magit-gerrit-ssh-creds
+                   (magit-gerrit-detect-ssh-creds remote-url))
+               (string-match magit-gerrit-ssh-creds remote-url))
       ;; update keymap with prefix incase it has changed
       (define-key magit-gerrit-mode-map magit-gerrit-popup-prefix 'magit-gerrit-build-popup)
       (magit-gerrit-mode t))))

--- a/magit-gerrit.el
+++ b/magit-gerrit.el
@@ -476,7 +476,8 @@ Succeed even if branch already exist
                                    (error "Select a commit for review"))))
          (branch-remote (and branch (magit-get "branch" branch "remote")))
          (branch-merge (if (string= remote-branch "")
-                           (magit-gerrit-query-remote-branch-merge))))
+                           (magit-gerrit-query-remote-branch-merge)
+                         remote-branch)))
     ;; (message "Args: %s "
     ;;	     (concat rev ":" branch-pub))
     (when (or (string= branch-remote ".")


### PR DESCRIPTION
1. `Use receivepack to add default reviewers` :  An opition to avoid  adding receivepack to .git/config.
2. `Fix when branch merge is missing in config`: query for merge branch when there is no `branch` section in config, or the push to gerrit will fail. 
3. `Mod indent the code`: just indent the code