### PR TITLE
Fix that customized prefix key is not well applied

### DIFF
--- a/magit-gerrit.el
+++ b/magit-gerrit.el
@@ -503,7 +503,7 @@ Succeed even if branch already exist
   :options '((?m "Comment"                      "--message "       magit-gerrit-read-comment)))
 
 ;; Attach Magit Gerrit to Magit's default help popup
-(magit-define-popup-action 'magit-dispatch-popup ?R "Gerrit"
+(magit-define-popup-action 'magit-dispatch-popup (string-to-char magit-gerrit-popup-prefix) "Gerrit"
   'magit-gerrit-popup)
 
 (magit-define-popup magit-gerrit-copy-review-popup


### PR DESCRIPTION
The customized prefix key was not being applied to magit main popup. This PR fixes that.
I don't think it is what you intended, but if the original behavior is really what you expects,  just discard this PR.