### PR TITLE
Don't use obsolete (since 2.12.0) magit API

### DIFF
--- a/magit-gerrit.el
+++ b/magit-gerrit.el
@@ -248,7 +248,7 @@ Succeed even if branch already exist
 		 (magit-gerrit-pretty-print-review num subj owner-name isdraft)
 		 'magit-gerrit-jobj
 		 jobj))
-	(unless (magit-section-hidden (magit-current-section))
+	(unless (oref (magit-current-section) hidden)
 	  (magit-gerrit-wash-approvals approvs))
 	(add-text-properties beg (point) (list 'magit-gerrit-jobj jobj)))
       t)))
@@ -400,9 +400,9 @@ Succeed even if branch already exist
 (defun magit-gerrit-push-review (status)
   (let* ((branch (or (magit-get-current-branch)
 		     (error "Don't push a detached head.  That's gross")))
-	 (commitid (or (when (eq (magit-section-type (magit-current-section))
+	 (commitid (or (when (eq (oref (magit-current-section) type)
 				 'commit)
-			 (magit-section-value (magit-current-section)))
+			 (oref (magit-current-section) value))
 		       (error "Couldn't find a commit at point")))
 	 (rev (magit-rev-parse (or commitid
 				   (error "Select a commit for review"))))


### PR DESCRIPTION
Use (oref ... {type,value,hidden}) instead of
(magit-section-{type,value,hidden})